### PR TITLE
feat: 상세페이지 관리자 페이지 접근 불가

### DIFF
--- a/client/src/pages/RecipeDetail/RecipeInfo.js
+++ b/client/src/pages/RecipeDetail/RecipeInfo.js
@@ -133,12 +133,19 @@ export default function RecipeInfo({
         </TitleContainer>
         <UserContainer>
           <WriterInfo>
-            <Link to={`/userpage/${cocktailDetail.userId}`}>
+            {cocktailDetail.userId === 4 ? (
               <FlexContainer>
                 <PiUserCircleFill size="24px" />
-                <NameP>{cocktailDetail.userName}</NameP>
+                <NameP>관리자</NameP>
               </FlexContainer>
-            </Link>
+            ) : (
+              <Link to={`/userpage/${cocktailDetail.userId}`}>
+                <FlexContainer>
+                  <PiUserCircleFill size="24px" />
+                  <NameP>{cocktailDetail.userName}</NameP>
+                </FlexContainer>
+              </Link>
+            )}
             <p className="mt-1 text-[10px]">
               {getTime(cocktailDetail.createdAt)}
             </p>


### PR DESCRIPTION
### feat: 상세페이지 관리자 페이지 접근 불가
- 레시피 상세페이지에서 레시피 작성자 선택 시 해당 작성자 유저페이지로 이동하지만, 관리자 유저페이지로는 이동 못하게 했습니다.