### PR TITLE
색깔 랜덤 함수 최적화

### DIFF
--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -27,25 +27,27 @@ export default function Header() {
 
   const name = localStorage.getItem('name');
   const userid = localStorage.getItem('userId');
+
   // 글자 색 바꾸기
   useEffect(() => {
-    // 0.2초마다 함수 실행
-    const interval = setInterval(generateRandomColor, 200);
-
-    return () => {
-      clearInterval(interval); // 컴포넌트가 언마운트될 때 interval을 정리합니다.
+    let animationFrameId;
+    let lastTime = 0;
+    const generateRandomColor = (timestamp) => {
+      if (timestamp - lastTime >= 200) {
+        setRandomColor(getRandomColor());
+        lastTime = timestamp;
+      }
+      animationFrameId = requestAnimationFrame(generateRandomColor);
     };
-  }, []);
-
-  // 색깔 랜덤으로 띄우는 함수
-  const generateRandomColor = () => {
-    const letters = '0123456789ABCDEF';
-    let color = '#';
-    for (let i = 0; i < 6; i++) {
-      color += letters[Math.floor(Math.random() * 16)];
+    if (hovered) {
+      animationFrameId = requestAnimationFrame(generateRandomColor);
+    } else {
+      cancelAnimationFrame(animationFrameId);
     }
-    setRandomColor(color);
-  };
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [hovered]);
 
   const randomColorHandler = () => {
     setHovered(true);
@@ -194,6 +196,15 @@ export default function Header() {
     </HeaderContainer>
   );
 }
+
+const getRandomColor = () => {
+  const letters = '0123456789ABCDEF';
+  let color = '#';
+  for (let i = 0; i < 6; i++) {
+    color += letters[Math.floor(Math.random() * 16)];
+  }
+  return color;
+};
 
 const HeaderContainer = tw.header`
   fixed


### PR DESCRIPTION
### setInterval 함수는 프레임을 고려하지않고 시간이 지나면 실행되는 함수라 싱글 스레드인 자바스크립트 특성상 1프레임씩 밀리는 현상이 발생했습니다.

### 백그라운드에서도 0.2초마다 계속해서 실행되기때문에 불필요한 cpu 리소스를 잡아먹게됩니다.

### requestAnimationFrame을 이용해서 위의 문제를 해결했습니다.
![랜덤 색깔 리팩토링](https://github.com/codestates-seb/seb44_main_002/assets/88226519/83811c16-06cd-4816-9466-2e241f6b4f10)
